### PR TITLE
feat: improve display of datastore dictionary

### DIFF
--- a/ckanext/virginia_schema/templates/scheming/package/resource_read.html
+++ b/ckanext/virginia_schema/templates/scheming/package/resource_read.html
@@ -10,14 +10,11 @@
 {%- set schema = h.scheming_get_dataset_schema(dataset_type) -%}
 
 {% block resource_additional_information_inner %}
-  {% set ddict=h.datastore_dictionary(res.id) %}
-  {% if res.datastore_active and h.is_data_dict_active(ddict) %}
-    <section class="module data-dictionary">
-      {% set ddict=h.datastore_dictionary(res.id) %}
+  {% if res.datastore_active %}
+    {% set ddict=h.datastore_dictionary(res.id) %}
+    {% if h.is_data_dict_active(ddict) %}
       <div class="module-content">
-        <h2>
-          {{ _('Data Dictionary') }}
-        </h2>
+        <h2>{{ _('Data Dictionary') }}</h2>
         <table class="table table-striped table-bordered table-condensed" data-module="table-toggle-more">
           <thead>
             <tr>
@@ -27,19 +24,18 @@
               <th scope="col">{{ _('Description') }}</th>
             </tr>
           </thead>
-          {% for f in ddict %}
-            <tr {% if loop.index > 5 %}class="toggle-more"{% endif %}>
-              <td>{{ f.id }}</td>
-              <td>{{ f.type }}</td>
-              <td>{{ f.get('info', {}).label }}</td>
-              <td>{{ h.render_markdown(f.get('info', {}).notes) }}</td>
+          {% for field in ddict %}
+            <tr {% if loop.index > 10 %}class="toggle-more"{% endif %}>
+              <td>{{ field.id }}</td>
+              <td>{{ field.type }}</td>
+              <td>{{ field.get('info', {}).label }}</td>
+              <td>{{ h.render_markdown(field.get('info', {}).notes) }}</td>
             </tr>
           {% endfor %}
         </table>
       </div>
-    </section>
+    {% endif %}
   {% endif %}
-
   <div class="module-content">
     <h2>{{ _('Additional Information') }}</h2>
     <table class="table table-striped table-bordered table-condensed" data-module="table-toggle-more">
@@ -74,31 +70,18 @@
             <td>{{ res.mimetype_inner or res.mimetype or res.format or _('unknown') }}</td>
           </tr>
         {%- endblock -%}
-{#
-        {%- block resource_license -%}
+        {% if res_info.get('columns') %}
           <tr>
-            <th scope="row">{{ _('License') }}</th>
-            <td>{% snippet "snippets/license.html", pkg_dict=pkg, text_only=True %}</td>
+            <th scope="row">{{ _('Columns') }}</th>
+            <td>{{ res_info.get('columns')}}</td>
           </tr>
-        {%- endblock -%}
-#}
-        {% block resource_columns %}
-          {% if res_info.get('columns') %}
-            <tr>
-              <th scope="row">{{ _('Columns') }}</th>
-              <td>{{ res_info.get('columns')}}</td>
-            </tr>
-          {% endif %}
-        {% endblock %}
-        {% block resource_rows %}
-          {% if res_info.get('rows') %}
-            <tr>
-              <th scope="row">{{ _('Rows') }}</th>
-              <td>{{ res_info.get('rows')}}</td>
-            </tr>
-          {% endif %}
-        {% endblock %}
-       
+        {% endif %}
+        {% if res_info.get('rows') %}
+          <tr>
+            <th scope="row">{{ _('Rows') }}</th>
+            <td>{{ res_info.get('rows')}}</td>
+          </tr>
+        {% endif %}
         {%- block resource_fields -%}
           {%- for field in schema.resource_fields -%}
             {%- if field.field_name not in exclude_fields


### PR DESCRIPTION
# Description
- Calls `datastore_dictionary` only when the datastore is active and removes the duplicate call when rendering the data dictionary.
- Cleans up the scheming resource_read template.
- Show more dictionary rows before the table’s “show more” toggle (5 → 10).
